### PR TITLE
Add minheap and tests

### DIFF
--- a/heaps/minheap.py
+++ b/heaps/minheap.py
@@ -1,0 +1,76 @@
+from heaps.base import Heap
+
+
+class MinHeap(Heap):
+    """vanilla min-heap priority queue"""
+
+    class Node:
+        def __init__(self, data: dict, name=None):
+            self.key = data["key"]
+            self.name = name
+            self.data = data
+
+    heap = []
+
+    def _upheap(self, pos=None):
+        """up-heap element at given pos in heap array"""
+        child = pos or len(self.heap) - 1
+        parent = (child - 1) // 2
+
+        while child and self.heap[child].key < self.heap[parent].key:
+            self.heap[child], self.heap[parent] = self.heap[parent], self.heap[child]
+            child = parent
+            parent = (child - 1) // 2
+
+    def _downheap(self):
+        """downheap element"""
+        if len(self.heap) < 2:
+            return
+
+        item = 0
+        while (2 * item + 1) < len(self.heap):
+            child = 2 * item + 1
+            if (2 * item + 2) < len(self.heap) and self.heap[
+                2 * item + 2
+            ].key < self.heap[2 * item + 1].key:
+                child = 2 * item + 2
+            if self.heap[child].key > self.heap[item].key:
+                return
+            self.heap[child], self.heap[item] = self.heap[item], self.heap[child]
+            item = child
+
+    def insert(self, data: dict, name=None):
+        node = self.Node(data, name)
+        self.heap.append(node)
+        self._upheap()
+        return node
+
+    def find_min(self):
+        if not self.heap:
+            return None
+        # TODO: Why heap[1] instead of heap[0]?
+        return self.heap[1]
+
+    def extract_min(self) -> Node:
+        """delete minimum element"""
+        if not self.heap:
+            return None
+
+        self.heap[0], self.heap[-1] = self.heap[-1], self.heap[0]
+        data = self.heap.pop()
+        self._downheap()
+        return data
+
+    def decrease_key(self, node: Node, key):
+        if key >= node.key:
+            raise ValueError("Cannot decrease key with value >= current key")
+        if node in self.heap:  # TODO: remove O(n) search
+            pos = self.heap.index(node)
+            self.heap[pos].key = key
+            self._upheap(pos)
+
+    def show(self):
+        print(self.heap)
+
+    def __len__(self):
+        return len(self.heap)

--- a/main.py
+++ b/main.py
@@ -10,13 +10,11 @@ from test_graphs.graph_generator import *
 from heaps.fibonacci import FibHeap
 from heaps.violation import ViolationHeap
 from heaps.quake import QuakeHeap
-#from heaps.min import MinHeap
-#from heaps.quake import QuakeHeap
+from heaps.minheap import MinHeap
 #from heaps.rankparing import RankPairingHeap
 
 
-HEAPS = ["Quake", "Fibonacci", "Violation"]
-#HEAPS = ["Fibonacci"]
+HEAPS = ["Quake", "Fibonacci", "Violation", "MinHeap"]
 
 def get_heap(heap_choice):
     """Get specified heap instance."""
@@ -24,7 +22,7 @@ def get_heap(heap_choice):
         heap = FibHeap()
     elif heap_choice == "Violation":
         heap = ViolationHeap()
-    elif heap_choice == "Min":
+    elif heap_choice == "MinHeap":
         heap = MinHeap()
     elif heap_choice == "Quake":
         heap = QuakeHeap()

--- a/tests/test_minheap.py
+++ b/tests/test_minheap.py
@@ -1,0 +1,54 @@
+import pytest
+from heaps import minheap
+
+# Set up an empty MinHeap for test functions
+@pytest.fixture
+def uut():
+    return minheap.MinHeap()
+
+
+def test_insert(uut):
+    node = {"key": 5, "value": "apples"}
+    test_node = uut.insert(node, node["value"])
+    assert test_node.key == 5
+    assert test_node.name == "apples"
+
+
+def test_find_min(uut):
+    uut.insert({"key": 5})
+    uut.insert({"key": 4})
+    uut.insert({"key": 7})
+    uut.insert({"key": 9})
+    uut.insert({"key": 67})
+    uut.extract_min()  # Extract 4
+    uut.extract_min()  # Extract 5
+    assert uut.find_min().key == 7
+
+
+def test_extract_min(uut):
+    uut.insert({"key": 5})
+    uut.insert({"key": 4})
+    uut.insert({"key": 7})
+    uut.insert({"key": 9})
+    uut.insert({"key": 67})
+    assert uut.extract_min().key == 4
+    assert uut.extract_min().key == 5
+
+
+def test_decrease_key(uut):
+    uut.insert({"key": 5})
+    uut.insert({"key": 4})
+    x = uut.insert({"key": 100})
+    y = uut.insert({"key": 9})
+    uut.insert({"key": 67})
+    uut.extract_min()
+    uut.decrease_key(x, 3)
+    assert uut.extract_min().key == 3  # extract x
+    uut.decrease_key(y, 8)
+    assert y.key == 8
+
+
+def test_decrease_key_greater(uut):
+    x = uut.insert({"key": 5})
+    with pytest.raises(ValueError):
+        uut.decrease_key(x, 10)


### PR DESCRIPTION
There's a few TODOs in here I'm not sure about.

```py
    def find_min(self):
        if not self.heap:
            return None
        # TODO: Why heap[1] instead of heap[0]?
        return self.heap[1]
```

For some reason, in `test_find_min`, this returns 5 instead of 7. Seems like the heap list isn't being updated until later.

```py
    def decrease_key(self, node: Node, key):
        if key >= node.key:
            raise ValueError("Cannot decrease key with value >= current key")
        if node in self.heap:  # TODO: remove O(n) search
            pos = self.heap.index(node)
            self.heap[pos].key = key
            self._upheap(pos)
 ```
 
 What should we do to remove O(N) search? Priority for fixing MinHeap is pretty low since we already have 4 other heaps.